### PR TITLE
修复一系列问题，简单优化一些用法和结构

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Maven target directory
+target/
+
+# Maven POM backup files
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+
+# Maven wrapper files
+mvn/timing.properties
+mvn/wrapper/maven-wrapper.jar
+
+# Eclipse-specific files (if using Eclipse IDE)
+project
+classpath
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>Famara</name>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/com/wenkrang/famara/Famara.java
+++ b/src/main/java/com/wenkrang/famara/Famara.java
@@ -179,16 +179,16 @@ public final class Famara extends JavaPlugin {
 
         ConsoleLoger.info("Initializing photo storage directory");
         // 初始化照片存储目录
-        mkdir(new File("./plugins/Famara/pictures"));
+        mkdir(new File(getDataFolder(), "pictures"));
 
-        mkdir(new File("./plugins/Famara/players"));
+        mkdir(new File(getDataFolder(), "players"));
 
-        mkdir(new File("./plugins/Famara/update"));
-        loadPack("language.yml", new File("./plugins/Famara/language.yml"));
-        text.config = YamlConfiguration.loadConfiguration(new File("./plugins/Famara/language.yml"));
+        mkdir(new File(getDataFolder(), "update"));
+        loadPack("language.yml", new File(getDataFolder(), "language.yml"));
+        text.config = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "language.yml"));
         ConsoleLoger.info("Loading color configuration file");
         // 加载颜色配置文件
-        File file = new File("./plugins/Famara/colors.yml");
+        File file = new File(getDataFolder(), "colors.yml");
         loadPack("colors.yml", file);
         try {
             yamlConfiguration.load(file);
@@ -255,13 +255,15 @@ public final class Famara extends JavaPlugin {
             @Override
             public void run() {
                 try {
-                    UnsafeDownloader.downloadFile("https://gitee.com/wenkrang/Famara/raw/master/colors.yml", "./plugins/Famara/update/colors.yml");
-                    if (new File("./plugins/Famara/update/colors.yml").exists()) {
-                        YamlConfiguration updateYaml = YamlConfiguration.loadConfiguration(new File("./plugins/Famara/update/colors.yml"));
+                    File file = new File(getDataFolder(), "colors.yml");
+                    File updateFile = new File(getDataFolder(), "update/colors.yml");
+                    UnsafeDownloader.downloadFile("https://gitee.com/wenkrang/Famara/raw/master/colors.yml", updateFile);
+                    if (updateFile.exists()) {
+                        YamlConfiguration updateYaml = YamlConfiguration.loadConfiguration(updateFile);
                         if (updateYaml.getInt("version") > yamlConfiguration.getInt("version")) {
-                            new File("./plugins/Famara/colors.yml").delete();
-                            Files.copy(new File("./plugins/Famara/update/colors.yml").toPath(), new File("./plugins/Famara/colors.yml").toPath());
-                            yamlConfiguration.load(new File("./plugins/Famara/colors.yml"));
+                            file.delete();
+                            Files.copy(updateFile.toPath(), file.toPath());
+                            yamlConfiguration.load(file);
                             ConsoleLoger.info("Colors.yml updated");
                         }
                     }
@@ -305,7 +307,7 @@ public final class Famara extends JavaPlugin {
         ConsoleLoger.info("Loading items, photos and recipes");
         // 加载物品、照片和配方
         LoadItem.loadItem();
-        loadPhoto();
+        loadPhoto(getDataFolder());
         LoadRecipe.loadRecipe();
 
         ConsoleLoger.info("Loading complete, current version: alpine 1.0");

--- a/src/main/java/com/wenkrang/famara/Famara.java
+++ b/src/main/java/com/wenkrang/famara/Famara.java
@@ -24,7 +24,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.yaml.snakeyaml.Yaml;
 
 import java.awt.*;
 import java.io.File;
@@ -171,12 +170,12 @@ public final class Famara extends JavaPlugin {
 
 
         // 注册事件监听器
-        getServer().getPluginManager().registerEvents(new OpenBookE(), this);
-        getServer().getPluginManager().registerEvents(new BookClickE(), this);
-        getServer().getPluginManager().registerEvents(new OnUseCameraE(), this);
-        getServer().getPluginManager().registerEvents(new OnPlayerJoinE(), this);
-        getServer().getPluginManager().registerEvents(new OnLoadFilm(), this);
-        getServer().getPluginManager().registerEvents(new PlayerDownloadResPackE(), this);
+        new OpenBookE(this);
+        new BookClickE(this);
+        new OnUseCameraE(this);
+        OnPlayerJoinE playerJoinEvent = new OnPlayerJoinE(this);
+        new OnLoadFilm(this);
+        new PlayerDownloadResPackE(this);
 
         ConsoleLoger.info("Initializing photo storage directory");
         // 初始化照片存储目录
@@ -292,7 +291,7 @@ public final class Famara extends JavaPlugin {
         new BukkitRunnable() {
             @Override
             public void run() {
-                getServer().getOnlinePlayers().forEach(OnPlayerJoinE::startCheck);
+                getServer().getOnlinePlayers().forEach(playerJoinEvent::startCheck);
             }
         }.runTaskLater(Famara.getPlugin(Famara.class), 20);
 

--- a/src/main/java/com/wenkrang/famara/Famara.java
+++ b/src/main/java/com/wenkrang/famara/Famara.java
@@ -289,16 +289,6 @@ public final class Famara extends JavaPlugin {
             }
         }.runTaskTimer(Famara.getPlugin(Famara.class), 0 , 20);
 
-        // 对在线玩家执行加入检查
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                getServer().getOnlinePlayers().forEach(playerJoinEvent::startCheck);
-            }
-        }.runTaskLater(Famara.getPlugin(Famara.class), 20);
-
-
-
 
         ConsoleLoger.info("Initializing recipe book");
         // 初始化配方书主页面
@@ -309,6 +299,9 @@ public final class Famara extends JavaPlugin {
         LoadItem.loadItem();
         loadPhoto(getDataFolder());
         LoadRecipe.loadRecipe();
+
+        // 对在线玩家执行加入检查
+        getServer().getOnlinePlayers().forEach(playerJoinEvent::startCheck);
 
         ConsoleLoger.info("Loading complete, current version: alpine 1.0");
 

--- a/src/main/java/com/wenkrang/famara/Loader/LoadItem.java
+++ b/src/main/java/com/wenkrang/famara/Loader/LoadItem.java
@@ -25,7 +25,7 @@ public class LoadItem {
             itemMeta.setLore(lore);
             itemStack.setItemMeta(itemMeta);
 
-            ItemSystem.itemMap.put("recipeBook", itemStack);
+            ItemSystem.put("recipeBook", itemStack);
             RecipeBook.RecipeBookItem = itemStack;
         }
         {
@@ -39,7 +39,7 @@ public class LoadItem {
             itemMeta.setLore(lore);
             itemStack.setItemMeta(itemMeta);
 
-            ItemSystem.itemMap.put("photo", itemStack);
+            ItemSystem.put("photo", itemStack);
         }
         {
             ItemStack itemStack = new ItemStack(Material.FILLED_MAP);
@@ -52,7 +52,7 @@ public class LoadItem {
             itemMeta.setLore(lore);
             itemStack.setItemMeta(itemMeta);
 
-            ItemSystem.itemMap.put("photo_unPull", itemStack);
+            ItemSystem.put("photo_unPull", itemStack);
         }
         {
             ItemStack itemStack = new ItemStack(Material.STICK);
@@ -82,7 +82,7 @@ public class LoadItem {
             itemMeta.setItemModel(new NamespacedKey("famara", "famara_close"));
             itemMeta.setLore(lore);
             itemStack.setItemMeta(itemMeta);
-            ItemSystem.itemMap.put("camera", itemStack);
+            ItemSystem.put("camera", itemStack);
             RecipeBook.mainPage.items().put(0, itemStack);
             ArrayList<ItemStack> objects = new ArrayList<>();
             objects.add(new ItemStack(Material.LEVER));
@@ -126,7 +126,7 @@ public class LoadItem {
             itemMeta.setItemModel(new NamespacedKey("famara", "famara_close"));
             itemMeta.setLore(lore);
             itemStack.setItemMeta(itemMeta);
-            ItemSystem.itemMap.put("camera_filmed", itemStack);
+            ItemSystem.put("camera_filmed", itemStack);
         }
         {
             ItemStack itemStack = new ItemStack(Material.PAPER);
@@ -144,7 +144,7 @@ public class LoadItem {
             itemMeta.setLore(lore);
             itemMeta.setItemModel(new NamespacedKey("famara", "film_box"));
             itemStack.setItemMeta(itemMeta);
-            ItemSystem.itemMap.put("filmBox", itemStack);
+            ItemSystem.put("filmBox", itemStack);
             RecipeBook.mainPage.items().put(1, itemStack);
             ArrayList<ItemStack> objects = new ArrayList<>();
             //按照上面的写配方，配方写为：青金石，萤石，绿宝石，火药，火药，火药，纸，纸，纸

--- a/src/main/java/com/wenkrang/famara/Loader/LoadPhoto.java
+++ b/src/main/java/com/wenkrang/famara/Loader/LoadPhoto.java
@@ -14,12 +14,12 @@ import java.util.Objects;
 import java.util.logging.Logger;
 
 public class LoadPhoto {
-    public static void loadPhoto() {
-        File pictureDir = new File("./plugins/Famara/pictures/");
+    public static void loadPhoto(File dataFolder) {
+        File pictureDir = new File(dataFolder, "pictures");
         for (File file : Objects.requireNonNull(pictureDir.listFiles())) {
             String name = file.getName();
             String substring = name.substring(0, name.lastIndexOf('.'));
-            File picture = new File("./plugins/Famara/pictures/" + substring + ".png");
+            File picture = new File(dataFolder, "pictures/" + substring + ".png");
 
             try {
                 BufferedImage image = ImageIO.read(picture);

--- a/src/main/java/com/wenkrang/famara/Loader/LoadRecipe.java
+++ b/src/main/java/com/wenkrang/famara/Loader/LoadRecipe.java
@@ -17,17 +17,17 @@ public class LoadRecipe {
         BookPage mainPage = RecipeBook.mainPage;
         Map<Integer, ArrayList<ItemStack>> recipes = mainPage.Recipes();
         recipes.forEach((index, itemStacks) -> {
-            ShapedRecipe shapedRecipe = new ShapedRecipe(new NamespacedKey(Famara.getPlugin(Famara.class), String.valueOf(index)),mainPage.items().get(index))
+            ShapedRecipe shapedRecipe = new ShapedRecipe(new NamespacedKey(Famara.getPlugin(Famara.class), String.valueOf(index)),mainPage.items().get(index).clone())
                     .shape("qwe","rty","uio");
-            shapedRecipe.setIngredient('q', new RecipeChoice.ExactChoice(itemStacks.get(0)));
-            shapedRecipe.setIngredient('w', new RecipeChoice.ExactChoice(itemStacks.get(1)));
-            shapedRecipe.setIngredient('e', new RecipeChoice.ExactChoice(itemStacks.get(2)));
-            shapedRecipe.setIngredient('r', new RecipeChoice.ExactChoice(itemStacks.get(3)));
-            shapedRecipe.setIngredient('t', new RecipeChoice.ExactChoice(itemStacks.get(4)));
-            shapedRecipe.setIngredient('y', new RecipeChoice.ExactChoice(itemStacks.get(5)));
-            shapedRecipe.setIngredient('u', new RecipeChoice.ExactChoice(itemStacks.get(6)));
-            shapedRecipe.setIngredient('i', new RecipeChoice.ExactChoice(itemStacks.get(7)));
-            shapedRecipe.setIngredient('o', new RecipeChoice.ExactChoice(itemStacks.get(8)));
+            shapedRecipe.setIngredient('q', new RecipeChoice.ExactChoice(itemStacks.get(0).clone()));
+            shapedRecipe.setIngredient('w', new RecipeChoice.ExactChoice(itemStacks.get(1).clone()));
+            shapedRecipe.setIngredient('e', new RecipeChoice.ExactChoice(itemStacks.get(2).clone()));
+            shapedRecipe.setIngredient('r', new RecipeChoice.ExactChoice(itemStacks.get(3).clone()));
+            shapedRecipe.setIngredient('t', new RecipeChoice.ExactChoice(itemStacks.get(4).clone()));
+            shapedRecipe.setIngredient('y', new RecipeChoice.ExactChoice(itemStacks.get(5).clone()));
+            shapedRecipe.setIngredient('u', new RecipeChoice.ExactChoice(itemStacks.get(6).clone()));
+            shapedRecipe.setIngredient('i', new RecipeChoice.ExactChoice(itemStacks.get(7).clone()));
+            shapedRecipe.setIngredient('o', new RecipeChoice.ExactChoice(itemStacks.get(8).clone()));
 
             try {
                 Bukkit.getServer().addRecipe(shapedRecipe);

--- a/src/main/java/com/wenkrang/famara/event/BookClickE.java
+++ b/src/main/java/com/wenkrang/famara/event/BookClickE.java
@@ -70,15 +70,15 @@ public class BookClickE implements Listener {
 
                         inventory.setItem(16, event.getCurrentItem());
 
-                        inventory.setItem(3, recipes.get(event.getRawSlot() - 9).get(0));
-                        inventory.setItem(4, recipes.get(event.getRawSlot() - 9).get(1));
-                        inventory.setItem(5, recipes.get(event.getRawSlot() - 9).get(2));
-                        inventory.setItem(12, recipes.get(event.getRawSlot() - 9).get(3));
-                        inventory.setItem(13, recipes.get(event.getRawSlot() - 9).get(4));
-                        inventory.setItem(14, recipes.get(event.getRawSlot() - 9).get(5));
-                        inventory.setItem(21, recipes.get(event.getRawSlot() - 9).get(6));
-                        inventory.setItem(22, recipes.get(event.getRawSlot() - 9).get(7));
-                        inventory.setItem(23, recipes.get(event.getRawSlot() - 9).get(8));
+                        inventory.setItem(3, recipes.get(event.getRawSlot() - 9).get(0).clone());
+                        inventory.setItem(4, recipes.get(event.getRawSlot() - 9).get(1).clone());
+                        inventory.setItem(5, recipes.get(event.getRawSlot() - 9).get(2).clone());
+                        inventory.setItem(12, recipes.get(event.getRawSlot() - 9).get(3).clone());
+                        inventory.setItem(13, recipes.get(event.getRawSlot() - 9).get(4).clone());
+                        inventory.setItem(14, recipes.get(event.getRawSlot() - 9).get(5).clone());
+                        inventory.setItem(21, recipes.get(event.getRawSlot() - 9).get(6).clone());
+                        inventory.setItem(22, recipes.get(event.getRawSlot() - 9).get(7).clone());
+                        inventory.setItem(23, recipes.get(event.getRawSlot() - 9).get(8).clone());
 
                         event.getView().getPlayer().openInventory(inventory);
                     }

--- a/src/main/java/com/wenkrang/famara/event/BookClickE.java
+++ b/src/main/java/com/wenkrang/famara/event/BookClickE.java
@@ -1,5 +1,6 @@
 package com.wenkrang.famara.event;
 
+import com.wenkrang.famara.Famara;
 import com.wenkrang.famara.itemSystem.RecipeBook;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -17,8 +18,14 @@ import java.util.ArrayList;
 import java.util.Map;
 
 public class BookClickE implements Listener {
+    Famara plugin;
+    public BookClickE(Famara plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
     @EventHandler
-    public static void onClick(InventoryClickEvent event) {
+    public void onClick(InventoryClickEvent event) {
         if (event.getView().getTitle().equalsIgnoreCase("相机具体配方")) {
             if (event.getRawSlot() == 1) {
                 RecipeBook.openBook((Player) event.getWhoClicked());

--- a/src/main/java/com/wenkrang/famara/event/OnLoadFilm.java
+++ b/src/main/java/com/wenkrang/famara/event/OnLoadFilm.java
@@ -1,5 +1,6 @@
 package com.wenkrang.famara.event;
 
+import com.wenkrang.famara.Famara;
 import com.wenkrang.famara.lib.ItemUtils;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -8,8 +9,14 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
 public class OnLoadFilm implements Listener {
+    Famara plugin;
+    public OnLoadFilm(Famara plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
     @EventHandler
-    public static void LoadFilm(PlayerSwapHandItemsEvent event) {
+    public void LoadFilm(PlayerSwapHandItemsEvent event) {
         if (event.getOffHandItem() != null && event.getOffHandItem().getItemMeta() != null && event.getOffHandItem().getItemMeta().getItemModel() != null) {
             if (event.getOffHandItem().getItemMeta().getItemModel().getKey().equalsIgnoreCase("famara_close")) {
                 if (ItemUtils.getFilmAmount(event.getOffHandItem()) != 0) return;

--- a/src/main/java/com/wenkrang/famara/event/OnPlayerJoinE.java
+++ b/src/main/java/com/wenkrang/famara/event/OnPlayerJoinE.java
@@ -44,7 +44,7 @@ public class OnPlayerJoinE implements Listener {
     public void startCheck(Player player) {
 
         BossBar progress = Bukkit.createBossBar("冲洗进度", BarColor.WHITE, BarStyle.SOLID);
-        File PlayerFile = new File("./plugins/Famara/players/" + player.getName() + ".yml");
+        File PlayerFile = new File(plugin.getDataFolder(), "players/" + player.getName() + ".yml");
 
         if(!PlayerFile.exists()) {
             try {

--- a/src/main/java/com/wenkrang/famara/event/OnPlayerJoinE.java
+++ b/src/main/java/com/wenkrang/famara/event/OnPlayerJoinE.java
@@ -26,9 +26,14 @@ import java.util.Objects;
 import static com.wenkrang.famara.event.OnUseCameraE.getId;
 
 public class OnPlayerJoinE implements Listener {
+    Famara plugin;
+    public OnPlayerJoinE(Famara plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
 
     @EventHandler
-    public static void onHoldFilm(PlayerJoinEvent event) throws IOException {
+    public void onHoldFilm(PlayerJoinEvent event) throws IOException {
         if (event.getPlayer().getScoreboardTags().contains("FamaraResPackIncluded")) {
             event.getPlayer().removeScoreboardTag("FamaraResPackIncluded");
             LoadResourcePack.load(event.getPlayer(),false);
@@ -36,7 +41,7 @@ public class OnPlayerJoinE implements Listener {
         startCheck(event.getPlayer());
     }
 
-    public static void startCheck(Player player) {
+    public void startCheck(Player player) {
 
         BossBar progress = Bukkit.createBossBar("冲洗进度", BarColor.WHITE, BarStyle.SOLID);
         File PlayerFile = new File("./plugins/Famara/players/" + player.getName() + ".yml");

--- a/src/main/java/com/wenkrang/famara/event/OnPlayerJoinE.java
+++ b/src/main/java/com/wenkrang/famara/event/OnPlayerJoinE.java
@@ -51,7 +51,7 @@ public class OnPlayerJoinE implements Listener {
                 PlayerFile.createNewFile();
             }catch (Exception e){
             }
-            player.getInventory().addItem(ItemSystem.itemMap.get("recipeBook"));
+            player.getInventory().addItem(ItemSystem.get("recipeBook"));
         }
         new BukkitRunnable() {
             @Override

--- a/src/main/java/com/wenkrang/famara/event/OnUseCameraE.java
+++ b/src/main/java/com/wenkrang/famara/event/OnUseCameraE.java
@@ -41,7 +41,6 @@ public class OnUseCameraE implements Listener {
                 (event.getAction().equals(Action.RIGHT_CLICK_AIR) ||
                         event.getAction().equals(Action.RIGHT_CLICK_BLOCK))) {
             if (event.getPlayer().getInventory().getItemInMainHand().getItemMeta() == null) return;
-            //TODO:这里有大问题，会修改ItemMap
             if (!event.getPlayer().isSneaking() && event.getPlayer().getInventory().getItemInMainHand().getItemMeta().getDisplayName().equalsIgnoreCase("§f相机")) {
                 ItemStack itemInMainHand = event.getPlayer().getInventory().getItemInMainHand();
                 NamespacedKey itemModel = itemInMainHand.getItemMeta().getItemModel();
@@ -66,7 +65,7 @@ public class OnUseCameraE implements Listener {
                     ItemStack itemStack = PhotoRender.TakePhoto(event.getPlayer(), new File(plugin.getDataFolder(), "pictures"));
                     MapMeta mapMeta = (MapMeta) itemStack.getItemMeta();
                     int mapId = mapMeta.getMapId();
-                    ItemStack cameraFilmed = ItemSystem.itemMap.get("camera_filmed");
+                    ItemStack cameraFilmed = ItemSystem.get("camera_filmed");
                     List<String> lore = cameraFilmed.getItemMeta().getLore();
                     lore.set(3, "§7照片编号：" + mapId);
                     ItemMeta itemMeta = cameraFilmed.getItemMeta();
@@ -87,7 +86,7 @@ public class OnUseCameraE implements Listener {
                 int i = getId(event.getPlayer().getInventory().getItemInMainHand(), 3);
                 try {
                     event.getPlayer().getWorld().playSound(event.getPlayer().getLocation(), "famara:famara.pull.film", 1, 1);
-                    ItemStack itemStack = ItemSystem.itemMap.get("photo_unPull");
+                    ItemStack itemStack = ItemSystem.get("photo_unPull");
                     ItemMeta itemMeta = itemStack.getItemMeta();
                     itemMeta.setItemModel(new NamespacedKey("famara", "photo"));
                     List<String> lore = itemMeta.getLore();
@@ -99,7 +98,7 @@ public class OnUseCameraE implements Listener {
                     itemMeta.setLore(lore);
                     itemStack.setItemMeta(itemMeta);
                     event.getPlayer().getInventory().addItem(itemStack);
-                    ItemStack itemStack1 = ItemSystem.itemMap.get("camera");
+                    ItemStack itemStack1 = ItemSystem.get("camera");
                     ItemStack itemStack2 = ItemUtils.setFilmAmount(itemStack1, ItemUtils.getFilmAmount(event.getPlayer().getInventory().getItemInMainHand()));
                     event.getPlayer().getInventory().setItemInMainHand(itemStack2);
                 } catch (Exception e) {

--- a/src/main/java/com/wenkrang/famara/event/OnUseCameraE.java
+++ b/src/main/java/com/wenkrang/famara/event/OnUseCameraE.java
@@ -25,12 +25,18 @@ import java.io.IOException;
 import java.util.List;
 
 public class OnUseCameraE implements Listener {
+    Famara plugin;
+    public OnUseCameraE(Famara plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
     public static int getId(ItemStack itemStack, int index) {
         String s = itemStack.getItemMeta().getLore().get(index);
         return Integer.parseInt(s.replace("§7照片编号：", ""));
     }
     @EventHandler
-    public static void onUseCamera(PlayerInteractEvent event) {
+    public void onUseCamera(PlayerInteractEvent event) {
         if (event.getHand() == EquipmentSlot.HAND &&
                 (event.getAction().equals(Action.RIGHT_CLICK_AIR) ||
                         event.getAction().equals(Action.RIGHT_CLICK_BLOCK))) {

--- a/src/main/java/com/wenkrang/famara/event/OnUseCameraE.java
+++ b/src/main/java/com/wenkrang/famara/event/OnUseCameraE.java
@@ -63,7 +63,7 @@ public class OnUseCameraE implements Listener {
                         ItemStack itemInMainHand1 = ItemUtils.setFilmAmount(itemInMainHand, filmAmount - 1);
                         event.getPlayer().getInventory().setItemInMainHand(itemInMainHand1);
                     }
-                    ItemStack itemStack = PhotoRender.TakePhoto(event.getPlayer());
+                    ItemStack itemStack = PhotoRender.TakePhoto(event.getPlayer(), new File(plugin.getDataFolder(), "pictures"));
                     MapMeta mapMeta = (MapMeta) itemStack.getItemMeta();
                     int mapId = mapMeta.getMapId();
                     ItemStack cameraFilmed = ItemSystem.itemMap.get("camera_filmed");
@@ -122,15 +122,16 @@ public class OnUseCameraE implements Listener {
                     }else {
                         if (Bukkit.getMap(i) == null) return;
                         MapView map = null;
+                        File pictureFile = new File(plugin.getDataFolder(), "pictures/" + i + ".png");
                         if (Bukkit.getMap(i) == null) {
-                            if (new File("./plugins/Famara/pictures/" + i + ".png").exists()) {
+                            if (pictureFile.exists()) {
                                 map = Bukkit.createMap(event.getPlayer().getWorld());
                             }
                         } else {
                             map = Bukkit.getMap(i);
                         }
                         if (map != null) {
-                            itemStack = RenderLib.getPhoto(ImageIO.read(new File("./plugins/Famara/pictures/" + i + ".png")), map);
+                            itemStack = RenderLib.getPhoto(ImageIO.read(pictureFile), map);
                         }
                     }
                     event.getPlayer().getInventory().setItemInMainHand(itemStack);

--- a/src/main/java/com/wenkrang/famara/event/OpenBookE.java
+++ b/src/main/java/com/wenkrang/famara/event/OpenBookE.java
@@ -1,14 +1,21 @@
 package com.wenkrang.famara.event;
 
+import com.wenkrang.famara.Famara;
 import com.wenkrang.famara.Loader.LoadResourcePack;
 import com.wenkrang.famara.itemSystem.RecipeBook;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 public class OpenBookE implements Listener {
+    Famara plugin;
+    public OpenBookE(Famara plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
     @EventHandler
-    public static void onOpen(org.bukkit.event.player.PlayerInteractEvent event) {
+    public void onOpen(PlayerInteractEvent event) {
         if (event.getHand() == EquipmentSlot.HAND) {
             if (event.getPlayer().getInventory().getItemInMainHand().getItemMeta() != null) {
                 if (event.getPlayer()

--- a/src/main/java/com/wenkrang/famara/event/PlayerDownloadResPackE.java
+++ b/src/main/java/com/wenkrang/famara/event/PlayerDownloadResPackE.java
@@ -1,11 +1,18 @@
 package com.wenkrang.famara.event;
 
+import com.wenkrang.famara.Famara;
 import com.wenkrang.famara.lib.text;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 
 public class PlayerDownloadResPackE implements Listener {
+    Famara plugin;
+    public PlayerDownloadResPackE(Famara plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
     @EventHandler
     public static void onPlayerDownloadResPack(org.bukkit.event.player.PlayerResourcePackStatusEvent event) {
         PlayerResourcePackStatusEvent.Status status = event.getStatus();

--- a/src/main/java/com/wenkrang/famara/itemSystem/BookPage.java
+++ b/src/main/java/com/wenkrang/famara/itemSystem/BookPage.java
@@ -1,11 +1,15 @@
 package com.wenkrang.famara.itemSystem;
 
-import org.bukkit.inventory.CraftingRecipe;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Map;
 
-public record BookPage(String title, Map<Integer, ItemStack> items, Map<Integer, BookPage> References, Map<Integer, ArrayList<ItemStack>> Recipes) {
+public record BookPage(
+        String title,
+        Map<Integer, ItemStack> items,
+        Map<Integer, BookPage> References,
+        Map<Integer, ArrayList<ItemStack>> Recipes
+) {
 
 }

--- a/src/main/java/com/wenkrang/famara/itemSystem/ItemSystem.java
+++ b/src/main/java/com/wenkrang/famara/itemSystem/ItemSystem.java
@@ -2,9 +2,29 @@ package com.wenkrang.famara.itemSystem;
 
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ItemSystem {
-    public static @NotNull ConcurrentHashMap<String, ItemStack> itemMap = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, ItemStack> itemMap = new ConcurrentHashMap<>();
+    public static void put(@NotNull String id, @Nullable ItemStack sampleItem) {
+        if (sampleItem == null) {
+            itemMap.remove(id);
+        } else {
+            itemMap.put(id, sampleItem);
+        }
+    }
+    public static ItemStack get(@NotNull String id) {
+        ItemStack item = itemMap.get(id);
+        if (item == null) {
+            throw new IllegalArgumentException("找不到物品 " + id);
+        }
+        return item.clone();
+    }
+    @Nullable
+    public static ItemStack getOrNull(@NotNull String id) {
+        ItemStack item = itemMap.get(id);
+        return item == null ? null : item.clone();
+    }
 }

--- a/src/main/java/com/wenkrang/famara/itemSystem/RecipeBook.java
+++ b/src/main/java/com/wenkrang/famara/itemSystem/RecipeBook.java
@@ -40,7 +40,7 @@ public class RecipeBook {
 
         Map<Integer, ItemStack> items = mainPage.items();
         items.forEach((index, itemStack) -> {
-            inventory.setItem(index + 9, itemStack);
+            inventory.setItem(index + 9, itemStack.clone());
         });
     }
 }

--- a/src/main/java/com/wenkrang/famara/lib/UnsafeDownloader.java
+++ b/src/main/java/com/wenkrang/famara/lib/UnsafeDownloader.java
@@ -1,12 +1,13 @@
 package com.wenkrang.famara.lib;
 
 import javax.net.ssl.HttpsURLConnection;
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.net.URL;
 
 public class UnsafeDownloader {
-    public static void downloadFile(String urlString, String destinationFile) throws Exception {
+    public static void downloadFile(String urlString, File destinationFile) throws Exception {
         // 创建URL对象
         URL url = new URL(urlString);
         HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();

--- a/src/main/java/com/wenkrang/famara/render/PhotoRender.java
+++ b/src/main/java/com/wenkrang/famara/render/PhotoRender.java
@@ -37,7 +37,7 @@ public class PhotoRender {
 //    }
 
 
-    public static ItemStack TakePhoto(Player player) throws IOException {
+    public static ItemStack TakePhoto(Player player, File pictureFolder) throws IOException {
 
         MapView map = Bukkit.createMap(player.getWorld());
 
@@ -46,7 +46,7 @@ public class PhotoRender {
 
         //初始化照片
         BufferedImage image = new BufferedImage(128, 128, BufferedImage.TYPE_INT_RGB);
-        File picture = new File("./plugins/Famara/pictures/" + id + ".png");
+        File picture = new File(pictureFolder, id + ".png");
         try {
             boolean newFile = picture.createNewFile();
             if (!newFile) {

--- a/src/main/java/com/wenkrang/famara/render/RenderLib.java
+++ b/src/main/java/com/wenkrang/famara/render/RenderLib.java
@@ -78,7 +78,7 @@ public class RenderLib {
         map.addRenderer(mapRenderer);
 
         //发放照片
-        ItemStack itemStack = ItemSystem.itemMap.get("photo");
+        ItemStack itemStack = ItemSystem.get("photo");
         ItemMeta itemMeta = itemStack.getItemMeta();
         itemMeta.setItemModel(new NamespacedKey("famara", "photo"));
         MapMeta mapMeta = (MapMeta) itemMeta;


### PR DESCRIPTION
我主要做了这些事
+ 将编译目标改为 Java 17。从 1.20.5 开始才强制 Java 21，不是所有低版本用户都愿意用 Java 21
+ 添加 `.gitignore`，以免不必要的文件（例如编译后的 .class 等等）被添加到 git
+ 事件监听器添加插件主类实例，方便之后我要给一些功能添加到配置文件做开关和配置
+ 将所有使用了 `"./plugins/Famara"` 路径的 File 改为使用 `plugin.getDataFolder()`
+ 在通过 BookPage 读取物品时，应当复制一份物品，以免存进去的样例物品被修改
+ 在通过 ItemSystem 读取物品时，应当复制一份物品，以免存进去的样例物品被修改
+ 你的代码顺序写错了，应该先加载数据再对在线玩家执行加入检查，并不需要延时

暂时就先做这么多了，插件还有诸多问题没有解决，以后再说